### PR TITLE
Do not hardcode list

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
 
         <main>
             <form>
-                <input type="hidden" name="list" value="toDoList">
                 <label for="task"></label>
                 <input type="text" name="task" id="task" required placeholder="Add a task...">
                 <div class="submit-btn-container">

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 
         <main>
             <form>
+                <input type="hidden" name="list" value="toDoList">
                 <label for="task"></label>
                 <input type="text" name="task" id="task" required placeholder="Add a task...">
                 <div class="submit-btn-container">

--- a/script.js
+++ b/script.js
@@ -57,7 +57,8 @@ class ToDoList {
 
 // Currently we set up one default list, but it would be relatively straightforward
 // to add functionality to allow the user to create multiple lists.
-window.toDoList = new ToDoList('defaultList', true);
+const defaultListIdentifier = 'toDoList';
+window[defaultListIdentifier] = new ToDoList('defaultList', true);
 
 
 function updateDisplay(list) {
@@ -125,21 +126,25 @@ function updateDisplay(list) {
 }
 
 
-function handleFormInput(form) {
-
+function objFromFormData(form) {
     const myFormData = new FormData(form);
+    return(Object.fromEntries(myFormData));
+}
 
-    const myData = Object.fromEntries(myFormData);
 
-    const listToUse = myData.list;
+function handleFormInput(form) {
+    
+    const myData = objFromFormData(form);
 
-    //toDoList.addItem(myData.task);
+    // The list to use can be specified by a (hidden) form input, name=list.
+    // If that's not specified, we use the default set above.
+    const listToUse = myData.list || defaultListIdentifier;
+
     window[listToUse].addItem(myData.task);
 
     // Empty the input
     document.querySelector('#task').value = '';
 
-    //updateDisplay(toDoList);
     updateDisplay(window[listToUse]);
 
 }
@@ -155,10 +160,15 @@ myForm.addEventListener('submit', (event) => {
 
 const myFilterControl = document.querySelector('#filter');
 
-myFilterControl.addEventListener('input', () => {
-    updateDisplay(toDoList);
+myFilterControl.addEventListener('input', (event) => {
+    // Get the form that this filter control belongs to:
+    const myForm = event.target.form;
+    const myData = objFromFormData(myForm);
+    // Again, either use a specified list, or default:
+    const listToUse = myData.list || defaultListIdentifier;
+    updateDisplay(window[listToUse]);
 });
 
 
 // Call this on page load, so that a saved list is displayed if it exists
-updateDisplay(toDoList);
+updateDisplay(window[defaultListIdentifier]);

--- a/script.js
+++ b/script.js
@@ -57,7 +57,7 @@ class ToDoList {
 
 // Currently we set up one default list, but it would be relatively straightforward
 // to add functionality to allow the user to create multiple lists.
-const toDoList = new ToDoList('defaultList', true);
+window.toDoList = new ToDoList('defaultList', true);
 
 
 function updateDisplay(list) {
@@ -131,12 +131,16 @@ function handleFormInput(form) {
 
     const myData = Object.fromEntries(myFormData);
 
-    toDoList.addItem(myData.task);
+    const listToUse = myData.list;
+
+    //toDoList.addItem(myData.task);
+    window[listToUse].addItem(myData.task);
 
     // Empty the input
     document.querySelector('#task').value = '';
 
-    updateDisplay(toDoList);
+    //updateDisplay(toDoList);
+    updateDisplay(window[listToUse]);
 
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -147,18 +147,26 @@ function addHiddenInputEl(form, listIdentifier) {
     return newEl;
 }
 
+// For some reason, the checkbox isn't getting checked? :(
 /* test("updateDisplay should hide items marked done (not add them to document) if the filter is enabled", () => {
-    const testList = new ToDoList();
+    window.testList = new ToDoList();
+
+    const myForm = document.querySelector('form');
+    const newHiddenInputEl = addHiddenInputEl(myForm, 'testList');
+
     testList.addItem("Test item one");
     testList.addItem("Test item two");
     testList.toggleItemDone(0);
     updateDisplay(testList);
+
     const testEl = document.querySelector('#filter');
     const inputEvent = new InputEvent('input');
-    testEl.dispatchEvent(inputEvent);
-    const actual0 = document.querySelector('section').innerHTML;
+    testEl.dispatchEvent(inputEvent); */
+    //const actual0 = document.querySelector('section').innerHTML;
     // etc.
-}); */
+
+    //newHiddenInputEl.remove();
+//});
 
 
 //------------------------Testing handleFormInput function-------------------------------------

--- a/test/test.js
+++ b/test/test.js
@@ -154,22 +154,24 @@ test("updateDisplay should add a button to the document with a 'click' event lis
 
 //------------------------Testing handleFormInput function-------------------------------------
 
-//test("handleFormInput should add a new item to the list", () => {
-    /*  We can't use a test list here unless we change how the handleFormInput function works.
-        e.g. it could read a hidden input element in the form which tells it what form to use.
-        (And we could override that hidden element in the test.)
+test("handleFormInput should add a new item to the list", () => {
+    window.testList = new ToDoList();
 
-        In lieu of that, could try just adding an item to the default list? Snags:
-            - Need to find its index
-            - Need to remove it after we're done
-            - Risk of messing up working list if tests are run (is that really a problem?)
-    */
-    /* const testTextInputEl = myForm.querySelector('#task');
+    const myForm = document.querySelector('form');
+
+    const newHiddenInputEl = document.createElement('input');
+    newHiddenInputEl.setAttribute('type', 'hidden');
+    newHiddenInputEl.setAttribute('name', 'list');
+    newHiddenInputEl.setAttribute('value', 'testList');
+    myForm.prepend(newHiddenInputEl);
+
+    const testTextInputEl = myForm.querySelector('#task');
     testTextInputEl.value = 'Testing';
+
     const inputEvent = new InputEvent('submit');
     myForm.dispatchEvent(inputEvent);
-    console.log(toDoList.toDos);
+
     const actual0 = testList.toDos[0].task;
     const expected0 = 'Testing';
-    equal(actual0, expected0); */
-//});
+    equal(actual0, expected0);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -136,8 +136,17 @@ test("updateDisplay should add a button to the document with a 'click' event lis
     equal(actual0, expected0);
 });
 
-// This test has the same problem as the handleFormInput one:
-// the test list to use is hard-coded in script.js.
+
+// Helper function for a couple of tests:
+function addHiddenInputEl(form, listIdentifier) {
+    const newEl = document.createElement('input');
+    newEl.setAttribute('type', 'hidden');
+    newEl.setAttribute('name', 'list');
+    newEl.setAttribute('value', listIdentifier);
+    form.prepend(newEl);
+    return newEl;
+}
+
 /* test("updateDisplay should hide items marked done (not add them to document) if the filter is enabled", () => {
     const testList = new ToDoList();
     testList.addItem("Test item one");
@@ -155,15 +164,13 @@ test("updateDisplay should add a button to the document with a 'click' event lis
 //------------------------Testing handleFormInput function-------------------------------------
 
 test("handleFormInput should add a new item to the list", () => {
+    // For this test, the list instance needs to be global
+    // (so it can be referred to programmatically)
     window.testList = new ToDoList();
 
     const myForm = document.querySelector('form');
 
-    const newHiddenInputEl = document.createElement('input');
-    newHiddenInputEl.setAttribute('type', 'hidden');
-    newHiddenInputEl.setAttribute('name', 'list');
-    newHiddenInputEl.setAttribute('value', 'testList');
-    myForm.prepend(newHiddenInputEl);
+    const newHiddenInputEl = addHiddenInputEl(myForm, 'testList');
 
     const testTextInputEl = myForm.querySelector('#task');
     testTextInputEl.value = 'Testing';
@@ -174,4 +181,7 @@ test("handleFormInput should add a new item to the list", () => {
     const actual0 = testList.toDos[0].task;
     const expected0 = 'Testing';
     equal(actual0, expected0);
+
+    // Remove the hidden input element now we're done, so we don't add more than one!
+    newHiddenInputEl.remove();
 });


### PR DESCRIPTION
This PR is a bit unwieldy. I basically did it so we can finish our integration tests (although one still isn't working, I've no idea why!).

In summary:
- Set up a default identifier for the default todo list
- Make this default todo list a global variable (with a computed name)
- Change a couple of functions to use this computed name, rather than hardcode the list name
- Complete one unfinished test from before, which works now thanks to these changes
- Add a helper function for tests